### PR TITLE
Add Debian 8 build slaves

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -68,6 +68,10 @@ c['slaves'].append(OpenAFSBuildSlave("sun510_x86", max_builds=2))
 # solaris 11
 c['slaves'].append(OpenAFSBuildSlave("sun511_x86", max_builds=2))
 
+# Contact: Nathan Hatley
+c['slaves'].append(OpenAFSBuildSlave("debian8-amd64", max_builds=2))
+c['slaves'].append(OpenAFSBuildSlave("debian8-i386", max_builds=2))
+
 # 'slavePortnum' defines the TCP port to listen on. This must match the value
 # configured into the buildslaves (with their --master option)
 
@@ -138,6 +142,8 @@ semidaily_master_builders.append("freebsd8-amd64-builder")
 semidaily_master_builders.append("opensuse-tumbleweed-i386-builder")
 semidaily_master_builders.append("opensuse-tumbleweed-x86_64-builder") 
 semidaily_master_builders.append("ubuntu14-x86_64-builder") 
+semidaily_master_builders.append("debian8-amd64-builder") 
+semidaily_master_builders.append("debian8-i386-builder") 
 
 c['schedulers'] = []
 c['schedulers'].append(Scheduler(name="all", branch=None,
@@ -470,6 +476,34 @@ debian_arm_builder = {'name': "debian-arm-builder",
       }
 
 c['builders'].append(debian_arm_builder)
+
+
+######### debian 8 builders
+debian8factory = factory.BuildFactory()
+debian8factory.addstep(ShellCommand(command=["sleep","120"]))
+debian8factory.addstep(Gerrit(repourl=repourl, mode='full', method="fresh", retry=[60,3], timeout=3600))
+debian8factory.addStep(ShellCommand(command=["sh","regen.sh"],timeout=3600))
+debian8factory.addStep(Configure(command=["./configure","--enable-supergroups","--enable-namei-fileserver","--enable-pthreaded-ubik"]))
+debian8factory.addStep(Compile(command=["make","-j5"]))
+debian8factory.addStep(Compile(command=["make","-j5","dest"]))
+
+######### debian amd64 builder
+debian8_amd64_builder = {'name': "debian8-amd64-builder",
+      'slavename': "debian8-amd64",
+      'builddir': "debian8-amd64-builder",
+      'factory': debian8factory,
+      }
+
+c['builders'].append(debian8_amd64_builder)
+
+######### debian i386 builder
+debian8_i386_builder = {'name': "debian8-i386-builder",
+      'slavename': "debian8-i386",
+      'builddir': "debian8-i386-builder",
+      'factory': debian8factory,
+      }
+
+c['builders'].append(debian8_i386_builder)
 
 
 ######### ubunu x86_64 builder


### PR DESCRIPTION
I created a new factory for Debian 8 that removes some unnecessary build steps as they are already handled by the Gerrit source step.  I also added -j5 to make to handle the additional cores assigned to the VMs.  Builds complete in about 9 minutes.