### PR TITLE
Remove freebsd93 builder

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -59,7 +59,6 @@ c['slaves'].append(OpenAFSBuildSlave("opensuse-tumbleweed-i386", max_builds=2, n
 c['slaves'].append(OpenAFSBuildSlave("ubuntu14-x86_64", max_builds=2))
 
 # Contact: Garrett Wollman
-c['slaves'].append(OpenAFSBuildSlave("freebsd93-amd64", max_builds=2))
 c['slaves'].append(OpenAFSBuildSlave("freebsd100-i386", max_builds=2))
 
 # Contact: Michael Meffie 
@@ -98,7 +97,6 @@ from buildbot.changes.filter import ChangeFilter
 
 # gerrit-triggered builds for the master branch
 mybuilders = []
-mybuilders.append("freebsd93-amd64-builder")
 mybuilders.append("freebsd100-i386-builder")
 mybuilders.append("opensuse12-i386-builder")
 mybuilders.append("opensuse12-x86_64-builder")
@@ -110,7 +108,6 @@ mybuilders.append("fedora20-x86_64-builder")
 devel17_builders = []
 
 gerrit16_builders = []
-gerrit16_builders.append("freebsd93-amd64-builder")
 gerrit16_builders.append("freebsd100-i386-builder")
 gerrit16_builders.append("opensuse12-i386-builder")
 gerrit16_builders.append("opensuse12-x86_64-builder")
@@ -492,24 +489,6 @@ ubuntu14_64bit_builder = {'name': "ubuntu14-x86_64-builder",
 c['builders'].append(ubuntu14_64bit_builder)
 
 ######### freebsd builders
-freebsd93factory = factory.BuildFactory()
-freebsd93factory.addStep(ShellCommand(command=["sleep","120"]))
-freebsd93factory.addStep(Gerrit(repourl=repourl, mode="full", method="fresh", retry=[60,3],timeout=3600))
-freebsd93factory.addStep(ShellCommand(command=["git","gc","--auto"],timeout=3600))
-freebsd93factory.addStep(ShellCommand(command=["git","clean","-X","-f","-e","!.buildbot-sourcedata"]))
-freebsd93factory.addStep(ShellCommand(command=["sh","regen.sh"]))
-freebsd93factory.addStep(Configure(command=["./configure","--enable-supergroups","--enable-warnings","--enable-namei-fileserver","--with-bsd-kernel-headers=/usr/src/sys","--with-bsd-kernel-build=/usr/obj/usr/src/sys/GENERIC"]))
-freebsd93factory.addStep(Compile(command=["make"]))
-freebsd93factory.addStep(Compile(command=["make", "dest"]))
-
-freebsd93_amd64_builder = {'name': "freebsd93-amd64-builder",
-      'slavename': "freebsd93-amd64",
-      'builddir': "freebsd93-amd64-builder",
-      'factory': freebsd93factory,
-      }
-
-c['builders'].append(freebsd93_amd64_builder)
-
 
 freebsd100factory = factory.BuildFactory()
 freebsd100factory.addStep(ShellCommand(command=["sleep","120"]))


### PR DESCRIPTION
The machine is having (VM) trouble, and FreeBSD 9.x is getting
pretty long in the tooth.  It will be better to get a new amd64
FreeBSD machine spun up than to try to keep this one running.